### PR TITLE
Update commons-compress to 1.23.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -91,7 +91,7 @@
     <wagon-gitsite.version>0.3.1</wagon-gitsite.version>
     
     <!-- Dependency versions -->
-    <commons-compress.version>1.22</commons-compress.version>
+    <commons-compress.version>1.23.0</commons-compress.version>
     <junit.version>4.13.2</junit.version>
     <maven-plugin-annotations.version>3.6.0</maven-plugin-annotations.version>
     <maven-plugin-api.version>3.6.0</maven-plugin-api.version>

--- a/src/main/java/io/github/zlika/reproducible/ZipStripper.java
+++ b/src/main/java/io/github/zlika/reproducible/ZipStripper.java
@@ -30,6 +30,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.stream.Collectors;
 
+import org.apache.commons.compress.archivers.zip.X000A_NTFS;
 import org.apache.commons.compress.archivers.zip.X5455_ExtendedTimestamp;
 import org.apache.commons.compress.archivers.zip.ZipArchiveEntry;
 import org.apache.commons.compress.archivers.zip.ZipArchiveOutputStream;
@@ -218,6 +219,10 @@ public final class ZipStripper implements Stripper
         // Remove extended timestamps
         for (ZipExtraField field : entry.getExtraFields())
         {
+            if (field instanceof X000A_NTFS)
+            {
+                entry.removeExtraField(field.getHeaderId());
+            }
             if (field instanceof X5455_ExtendedTimestamp)
             {
                 entry.removeExtraField(field.getHeaderId());


### PR DESCRIPTION
commons-compress adds 0x000a headers with extended timestamps since https://issues.apache.org/jira/browse/COMPRESS-613 , remove those again (consistent with `X5455_ExtendedTimestamp`, and avoiding problems with timezone processing in particular situations)